### PR TITLE
Remove architecture_independent from leo_msgs

### DIFF
--- a/leo_msgs/package.xml
+++ b/leo_msgs/package.xml
@@ -26,7 +26,6 @@
   <exec_depend>builtin_interfaces</exec_depend>
 
   <export>
-    <architecture_independent/>
     <build_type>ament_cmake</build_type>
   </export>
 


### PR DESCRIPTION
In ROS 1, message packages did not create any binaries and were therefore architecture-independent packages.

In ROS 2, static typesupport results in library creation whenever messages are generated, which are not architecture-independent.

This should resolve the current build failure for building this package for RHEL: https://build.ros2.org/job/Hbin_rhel_el864__leo_msgs__rhel_8_x86_64__binary/