### PR TITLE
Change wheel ode friction params

### DIFF
--- a/leo_description/urdf/macros.xacro
+++ b/leo_description/urdf/macros.xacro
@@ -375,9 +375,11 @@
         <surface>
           <friction>
             <ode>
-              <mu>1.0</mu>
-              <mu2>1.0</mu2>
-              <fdir1>0 0 0</fdir1>
+              <mu>1</mu>
+              <mu2>1</mu2>
+              <slip1>0.035</slip1>
+              <slip2>0</slip2>
+              <fdir1>0 0 1</fdir1>
             </ode>
             <bullet>
               <friction>1</friction>
@@ -394,9 +396,11 @@
         <surface>
           <friction>
             <ode>
-              <mu>1.0</mu>
-              <mu2>1.0</mu2>
-              <fdir1>0 0 0</fdir1>
+              <mu>1</mu>
+              <mu2>1</mu2>
+              <slip1>0.035</slip1>
+              <slip2>0</slip2>
+              <fdir1>0 0 1</fdir1>
             </ode>
             <bullet>
               <friction>1</friction>
@@ -413,9 +417,11 @@
         <surface>
           <friction>
             <ode>
-              <mu>1.0</mu>
-              <mu2>1.0</mu2>
-              <fdir1>0 0 0</fdir1>
+              <mu>1</mu>
+              <mu2>1</mu2>
+              <slip1>0.035</slip1>
+              <slip2>0</slip2>
+              <fdir1>0 0 1</fdir1>
             </ode>
             <bullet>
               <friction>1</friction>
@@ -432,9 +438,11 @@
         <surface>
           <friction>
             <ode>
-              <mu>1.0</mu>
-              <mu2>1.0</mu2>
-              <fdir1>0 0 0</fdir1>
+              <mu>1</mu>
+              <mu2>1</mu2>
+              <slip1>0.035</slip1>
+              <slip2>0</slip2>
+              <fdir1>0 0 1</fdir1>
             </ode>
             <bullet>
               <friction>1</friction>


### PR DESCRIPTION
My [issue](https://github.com/gazebosim/gz-sim/issues/2174) in gz_sim repository was resolved and new ODE friction parameters were proposed. I tested those parameters with leo rover in our simulation and they work very well - rotating in place is as good as in bullet. However bullet is more efficient on all of the marsyard world and simulation runs more smoothly with it - that's why I'm not changing collision detection engines in those worlds in simulation. Despite of that I think it's useful if we provide a potential user with working parameters with ODE in case someone wants to create and use an ODE collision based world.