### PR TITLE
Remove imu system plugin from the robot

### DIFF
--- a/leo_description/urdf/macros.xacro
+++ b/leo_description/urdf/macros.xacro
@@ -505,9 +505,6 @@
         name="ignition::gazebo::systems::JointStatePublisher">
         <topic>${link_prefix}joint_states</topic>
       </plugin>
-      <plugin filename="libignition-gazebo-imu-system.so"
-        name="ignition::gazebo::systems::Imu">
-      </plugin>
     </gazebo>
 
     <gazebo reference="${link_prefix}imu_frame">


### PR DESCRIPTION
Imu system plugin in Gazebo is global and importing it each time when spawning a robot can result in a simulation crash. All of our worlds already include sensor system plugin (which includes IMU) and importing it from a robot macro is unncecessary.