### PR TITLE
Add dummy .sh file for .dsv hook

### DIFF
--- a/leo_description/CMakeLists.txt
+++ b/leo_description/CMakeLists.txt
@@ -16,6 +16,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/gz_sim_resource_path.sh")
 ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/gz_sim_resource_path.dsv")
 
 ament_package()


### PR DESCRIPTION
When building packages with ament_package `.dsv` files are not taken in properly unless there is a `.sh` file with the same name registered with `ament_environment_hooks`. This is not the case when building the package with `colcon`. This PR adds dummy `.sh` file so the the hooks work as expected under all circumstances.